### PR TITLE
[WIP] Towards more performant celery

### DIFF
--- a/config/ores-localdev.yaml
+++ b/config/ores-localdev.yaml
@@ -48,7 +48,7 @@ extractors:
 # Scorer models
 scorer_models:
   defaults:
-    class: revscoring.scorers.MLScorerModel
+    class: revscoring.scorer_models.MLScorerModel
   enwiki_revert:
     model_file: models/enwiki.reverted.linear_svc.model
 

--- a/ores/utilities/dev_server.py
+++ b/ores/utilities/dev_server.py
@@ -31,10 +31,16 @@ def main(argv=None):
             level=logging.DEBUG,
             format='%(asctime)s %(levelname)s:%(name)s -- %(message)s'
         )
+    else:
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s %(levelname)s:%(name)s -- %(message)s'
+        )
+
 
     app = server.configure(config)
     app.run(host="0.0.0.0",
             port=int(args['--port']),
             debug=True,
-            ssl_context="adhoc",
+            #ssl_context="adhoc",
             threaded=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ redis
 revscoring
 stopit
 yamlconf
-socketIO-client
+socketIO-client==0.5.6


### PR DESCRIPTION
This PR has a lot of changes that were necessary to develop and test ores performance locally.  This PR demonstrats keeping up with live enwiki with 4 rcstream bots in parallel. 

* Adds 'SENT' state to celery to handle parallel requests.
* Specifies socketIO-client==0.5.6 in requirements. (Old version required for old style socketio)
* Removes HTTPS by default for dev server. (Works with precached)
* Updates localdev config to use the right classpath for ScorerModel