### PR TITLE
Fixes WSGI error state for multi-param value errors

### DIFF
--- a/config/ores-localdev.yaml
+++ b/config/ores-localdev.yaml
@@ -48,7 +48,7 @@ extractors:
 # Scorer models
 scorer_models:
   defaults:
-    class: revscoring.scorers.MLScorerModel
+    class: revscoring.scorer_models.MLScorerModel
   enwiki_revert:
     model_file: models/enwiki.reverted.linear_svc.model
 

--- a/ores/wsgi/util.py
+++ b/ores/wsgi/util.py
@@ -19,4 +19,9 @@ def read_bar_split_param(request, param, default=None, type=str):
     values = read_param(request, param, default=default)
     if values is None:
         return []
-    return [type(value) for value in values.split("|")]
+    
+    try:
+        return [type(value) for value in values.split("|")]
+    except (ValueError, TypeError) as e:
+        raise ParamError("Could not interpret {0}. {1}"
+                         .format(param, str(e)))


### PR DESCRIPTION
read_bar_split_param() now returns a ParamError when it can't read as expected.

Also fixes reference to revscoring.scorers --> revscoring.scorer_models for recent refactor.