### PR TITLE
Add vagrant support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "debian/jessie64"
+  
+  config.vm.provision "shell", path: 'provision.bash'
+
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+end

--- a/celery-dev.service
+++ b/celery-dev.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Development celery runner for ORES
+
+[Service]
+ExecStart=/srv/ores/venv/bin/python /vagrant/utility celery_worker
+WorkingDirectory=/vagrant
+User=vagrant
+Group=vagrant
+Restart=on-failure

--- a/ores/utilities/dev_server.py
+++ b/ores/utilities/dev_server.py
@@ -36,5 +36,4 @@ def main(argv=None):
     app.run(host="0.0.0.0",
             port=int(args['--port']),
             debug=True,
-            ssl_context="adhoc",
             threaded=True)

--- a/uwsgi-dev.service
+++ b/uwsgi-dev.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Development web runner for ORES
+
+[Service]
+ExecStart=/srv/ores/venv/bin/python /vagrant/utility dev_server
+WorkingDirectory=/vagrant
+User=vagrant
+Group=vagrant
+Restart=on-failure


### PR DESCRIPTION
This allows a local development version of ORES to be setup by:

1. Download and install Vagrant
2. Download and install VirtualBox
3. Copy the `models` folder from ores-wikimedia-config into the ores checkout
4. Run `vagrant up` in your ores checkout
5. PROFIT

Step 3 needs to go away, but unsure how.

You can look at logs by doing

1. `vagrant ssh`
2. `sudo journalctl -f`

Both the wsgi server and the celery server should autorestart when their files change
but if they do not, you can do so with:

1. `vagrant ssh`
2. `sudo systemctl restart celery-dev uwsgi-dev`