### PR TITLE
Adds a queue_maxsize param to Celery() that only works for redis brokers.

### DIFF
--- a/config/ores-localdev.yaml
+++ b/config/ores-localdev.yaml
@@ -1,6 +1,6 @@
 # Top level configuration
 ores:
-  score_processor: local_timeout
+  score_processor: local_celery
   wsgi:
     application_root: ""
     url_prefix: ""
@@ -40,6 +40,7 @@ score_processors:
     CELERY_RESULT_SERIALIZER: 'pickle'
     CELERYD_CONCURRENCY: 16
     timeout: 15 # seconds
+    queue_maxsize: 100 # pending tasks
   timeout:
     class: ores.score_processors.Timeout
     timeout: 5 # seconds

--- a/config/ores-localdev.yaml
+++ b/config/ores-localdev.yaml
@@ -1,6 +1,6 @@
 # Top level configuration
 ores:
-  score_processor: local_celery
+  score_processor: local_timeout
   wsgi:
     application_root: ""
     url_prefix: ""

--- a/ores/errors.py
+++ b/ores/errors.py
@@ -1,0 +1,3 @@
+
+class ScoreProcessorOverloaded(RuntimeError):
+    pass

--- a/ores/metrics_collectors/logger.py
+++ b/ores/metrics_collectors/logger.py
@@ -26,6 +26,10 @@ class Logger(MetricsCollector):
                           .format(context, model, version, rev_id_count,
                                   duration))
 
+    def score_processor_overloaded(self, context, model, version, count=1):
+        self.logger.debug("score_processor_overloaded: " +
+                          "{0}.{1}.{2}".format(context, model, version))
+
     def score_processed(self, context, model, version, duration):
         self.logger.debug("score_processed: {0}.{1}.{2} in {3} seconds"
                           .format(context, model, version, duration))

--- a/ores/metrics_collectors/metrics_collector.py
+++ b/ores/metrics_collectors/metrics_collector.py
@@ -17,6 +17,9 @@ class MetricsCollector:
                               duration):
         raise NotImplementedError()
 
+    def score_processor_overloaded(self, context, model, version, count=1):
+        raise NotImplementedError()
+
     def score_processed(self, context, model, version, duration):
         raise NotImplementedError()
 

--- a/ores/metrics_collectors/null.py
+++ b/ores/metrics_collectors/null.py
@@ -15,6 +15,9 @@ class Null(MetricsCollector):
                               duration):
         pass
 
+    def score_processor_overloaded(self, context, model, version, count=1):
+        pass
+
     def score_processed(self, context, model, version, duration):
         pass
 

--- a/ores/metrics_collectors/statsd.py
+++ b/ores/metrics_collectors/statsd.py
@@ -78,6 +78,19 @@ class Statsd(MetricsCollector):
                         duration * 1000)
             pipe.timing("score_processed", duration * 1000)
 
+    def score_processor_overloaded(self, context, model, version, count=1):
+        with self.statsd_client.pipeline() as pipe:
+            pipe.incr("score_processor_overloaded.{0}.{1}.{2}"
+                      .format(context, model, version),
+                      count=count)
+            pipe.incr("score_processor_overloaded.{0}.{1}"
+                      .format(context, model),
+                      count=count)
+            pipe.incr("score_processor_overloaded.{0}".format(context),
+                      count=count)
+            pipe.incr("score_processor_overloaded",
+                      count=count)
+
     def score_cache_hit(self, context, model, version, count=1):
         with self.statsd_client.pipeline() as pipe:
             pipe.incr("score_cache_hit.{0}.{1}.{2}"

--- a/ores/score_processors/celery.py
+++ b/ores/score_processors/celery.py
@@ -118,8 +118,11 @@ class Celery(Timeout):
         # properties
         if self.redis is not None:
             queue_size = self.redis.llen("celery")
-            logger.warning("Queue size is too full {0}".format(queue_size))
-            return queue_size > self.queue_maxsize
+            if queue_size > self.queue_maxsize:
+                logger.warning("Queue size is too full {0}".format(queue_size))
+                return True
+            else:
+                return False
         else:
             return False
 

--- a/ores/score_processors/celery.py
+++ b/ores/score_processors/celery.py
@@ -218,6 +218,9 @@ REDIS_URL_RE = re.compile(
     r"(:(?P<port>[0-9]+))?" +
     r"(/(?P<db>[0-9]+))?"
 )
+"""
+Extracts the components of a redis URL as groups.
+"""
 
 
 def redis_from_url(url):

--- a/ores/wsgi/responses.py
+++ b/ores/wsgi/responses.py
@@ -22,3 +22,9 @@ def forbidden(message=None):
 def not_found(message=None):
     return error(404, 'not found',
                  message or "Nothing found at this location.")
+
+
+def server_overloaded(message=None):
+    return error(503, 'server overloaded',
+                 "Cannot process your request because the server is " + \
+                 "overloaded.  Try again in a few minutes.")

--- a/ores/wsgi/routes/scores.py
+++ b/ores/wsgi/routes/scores.py
@@ -1,3 +1,4 @@
+import queue
 from collections import defaultdict
 
 from flask import request
@@ -58,12 +59,15 @@ def configure(config, bp, score_processor):
         precache = "precache" in request.args
 
         # Generate scores for each model and merge them together
-        scores = defaultdict(dict)
-        for model in models:
-            model_scores = score_processor.score(context, model, rev_ids,
-                                                 precache=precache)
-            for rev_id in model_scores:
-                scores[rev_id][model] = model_scores[rev_id]
+        try:
+            scores = defaultdict(dict)
+            for model in models:
+                model_scores = score_processor.score(context, model, rev_ids,
+                                                     precache=precache)
+                for rev_id in model_scores:
+                    scores[rev_id][model] = model_scores[rev_id]
+        except queue.Full:
+            return responses.server_overloaded()
 
         return jsonify(scores)
 
@@ -93,8 +97,11 @@ def configure(config, bp, score_processor):
             return jsonify(score_processor[context][model].info())
 
         precache = "precache" in request.args
-        scores = score_processor.score(context, model, rev_ids,
-                                       precache=precache)
+        try:
+            scores = score_processor.score(context, model, rev_ids,
+                                           precache=precache)
+        except queue.Full:
+            return responses.server_overloaded()
         return jsonify(scores)
 
     # /scores/enwiki/reverted/4567890
@@ -113,8 +120,12 @@ def configure(config, bp, score_processor):
             return responses.not_found("Model '{0}' not available for {1}."
                                        .format(model, context))
         else:
-            scores = score_processor.score(context, model, [rev_id],
-                                           precache=precache)
+            try:
+                scores = score_processor.score(context, model, [rev_id],
+                                               precache=precache)
+            except queue.Full:
+                return responses.server_overloaded()
+
             return jsonify(scores)
 
     return bp

--- a/ores/wsgi/routes/scores.py
+++ b/ores/wsgi/routes/scores.py
@@ -1,10 +1,10 @@
-import queue
 from collections import defaultdict
 
 from flask import request
 from flask.ext.jsonpify import jsonify
 
 from .. import responses
+from ... import errors
 from ..util import ParamError, read_bar_split_param
 
 
@@ -66,7 +66,7 @@ def configure(config, bp, score_processor):
                                                      precache=precache)
                 for rev_id in model_scores:
                     scores[rev_id][model] = model_scores[rev_id]
-        except queue.Full:
+        except errors.ScoreProcessorOverloaded:
             return responses.server_overloaded()
 
         return jsonify(scores)
@@ -100,7 +100,7 @@ def configure(config, bp, score_processor):
         try:
             scores = score_processor.score(context, model, rev_ids,
                                            precache=precache)
-        except queue.Full:
+        except errors.ScoreProcessorOverloaded:
             return responses.server_overloaded()
         return jsonify(scores)
 
@@ -123,7 +123,7 @@ def configure(config, bp, score_processor):
             try:
                 scores = score_processor.score(context, model, [rev_id],
                                                precache=precache)
-            except queue.Full:
+            except errors.ScoreProcessorOverloaded:
                 return responses.server_overloaded()
 
             return jsonify(scores)


### PR DESCRIPTION
Note that this change will do a few things:
* Adds a new error response (503 -- server overloaded)
* A whole request will fail instantly when trying to score revisions if the queue is too full
* When the queue is too full, `score()` raises `errors.ScoreProcessorOverloaded`
* A WARNING will be raise when the queue is overfull
* A WARNING will be raised if queue_maxsize is set and Celery is not using a redis broker (because queue_maxsize can't be respected)
* Adds a `score_processor_overloaded` metric to the metrics_collectors.