### PR TITLE
Consistently use "probability" in the JSON returned for all models

### DIFF
--- a/ores/scorer_models/rev_id_scorer.py
+++ b/ores/scorer_models/rev_id_scorer.py
@@ -38,7 +38,7 @@ class RevIdScorer(ScorerModel):
 
         return {
             'prediction': prediction,
-            'probabilities': {
+            'probability': {
                 True: probability,
                 False: 1 - probability
             }


### PR DESCRIPTION
Clients such as mw-gadget-ScoredRevisions expect all models to follow
the same structure. The inclusion of "probabilities" instead of
"probability" caused JS errors when accessing https://test.wikipedia.org

E.g.:
https://ores.wmflabs.org/scores/ptwiki/?models=reverted&revids=123456
```json
{
  "123456": {
    "reverted": {
      "prediction": true,
      "probability": {
        "false": 0.020751023097118754,
        "true": 0.9792489769028813
      }
    }
  }
}
```
https://ores.wmflabs.org/scores/testwiki/?models=reverted&revids=123456
```json
{
  "123456": {
    "reverted": {
      "prediction": true,
      "probabilities": {
        "false": 0.35,
        "true": 0.65
      }
    }
  }
}
```