### PR TITLE
Try to appease travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_install:
   - sudo apt-get install -y g++ gfortran liblapack-dev libopenblas-dev python3-dev myspell-pt myspell-fa myspell-en-au  myspell-en-gb myspell-en-us myspell-en-za myspell-fr 
 install:
   - travis_wait pip install -r requirements.txt
+  - pip install statsd pylru
 script:
   - nosetests -v --with-coverage --cover-package=revscoring --quiet


### PR DESCRIPTION
This now passes: https://travis-ci.org/arlolra/ores/builds/101945348

But the logs say,
> nose.plugins.cover: ERROR: Coverage not available: unable to import coverage module