### PR TITLE
FIX 'render_template' not defined error

### DIFF
--- a/ores/wsgi/routes/__init__.py
+++ b/ores/wsgi/routes/__init__.py
@@ -7,7 +7,7 @@ def configure(config, bp, score_processor):
 
     @bp.route("/", methods=["GET"])
     def index():
-        return render_template("home.html")
+        return ui.render_template("home.html")
 
     bp = scores.configure(config, bp, score_processor)
     bp = ui.configure(config, bp)


### PR DESCRIPTION
This error was appearing if you try to open 'http://host:port/'