### PR TITLE
Adds celery and wsgi applications.

### DIFF
--- a/ores/applications/celery.py
+++ b/ores/applications/celery.py
@@ -1,0 +1,39 @@
+"""
+Runs a celery worker.
+
+Usage:
+    celery [--config-dir=<path>]... [--logging-config=<path>]
+
+Options:
+    -h --help                Prints this documentation
+    --config-dir=<path>      The path to a directory containing configuration
+                             [default: config/]
+    --logging-config=<path>  The path to a logging configuration file
+"""
+
+import logging
+
+import docopt
+
+from ..score_processors import Celery
+from .util import build_config
+
+
+def main(argv=None):
+    args = docopt.docopt(__doc__, argv=argv)
+
+    run(config_dirs=args['--config-dir'],
+        logging_config=args['--logging-config'])
+
+
+def run(*args, **kwargs):
+    application = build(*args, **kwargs)
+    logging.getLogger('ores').setLevel(logging.DEBUG)
+    application.worker_main(argv=["celery_worker", "--loglevel=INFO"])
+
+
+def build(*args, **kwargs):
+    config = build_config(*args, **kwargs)
+    score_processor = Celery.from_config(
+        config, config['ores']['score_processor'])
+    return score_processor.application

--- a/ores/applications/util.py
+++ b/ores/applications/util.py
@@ -1,0 +1,27 @@
+import glob
+import os.path
+import yamlconf
+import logging.config
+
+DEFAULT_DIRS = ["config/", "/etc/ores/"]
+
+
+def build_config(config_dirs=DEFAULT_DIRS,
+                 logging_config="logging_config.yaml"):
+    config_paths = []
+    for directory in config_dirs:
+        config_paths.extend(glob.glob(os.path.join(directory, "*.yaml")))
+    config_paths.sort()
+    config = yamlconf.load(*(open(p) for p in config_paths))
+
+    if logging_config is not None:
+        with open(logging_config) as f:
+            logging_config = yamlconf.load(f)
+            logging.config.dictConfig(logging_config)
+
+    if 'data_paths' in config['ores'] and \
+       'nltk' in config['ores']['data_paths']:
+        import nltk
+        nltk.data.path.append(config['ores']['data_paths']['nltk'])
+
+    return config

--- a/ores/applications/util.py
+++ b/ores/applications/util.py
@@ -8,17 +8,22 @@ DEFAULT_DIRS = ["config/", "/etc/ores/"]
 
 def build_config(config_dirs=DEFAULT_DIRS,
                  logging_config="logging_config.yaml"):
-    config_paths = []
+    # Loads files in alphabetical order based on the bare filename
+    config_file_paths = []
     for directory in config_dirs:
-        config_paths.extend(glob.glob(os.path.join(directory, "*.yaml")))
-    config_paths.sort()
-    config = yamlconf.load(*(open(p) for p in config_paths))
+        dir_glob = os.path.join(directory, "*.yaml")
+        config_file_paths.extend((os.path.basename(path), path)
+                                 for path in glob.glob(dir_glob))
+    config_file_paths.sort()
+    config = yamlconf.load(*(open(p) for fn, p in config_file_paths))
 
+    # Load logging config if specified
     if logging_config is not None:
         with open(logging_config) as f:
             logging_config = yamlconf.load(f)
             logging.config.dictConfig(logging_config)
 
+    # Add nltk data path if specified.
     if 'data_paths' in config['ores'] and \
        'nltk' in config['ores']['data_paths']:
         import nltk

--- a/ores/applications/wsgi.py
+++ b/ores/applications/wsgi.py
@@ -1,0 +1,36 @@
+"""
+Runs a uwsgi server.
+
+Usage:
+    wsgi [--config-dir=<path>]... [--logging-config=<path>]
+
+Options:
+    -h --help                Prints this documentation
+    --config-dir=<path>      The path to a directory containing configuration
+                             [default: config/]
+    --logging-config=<path>  The path to a logging configuration file
+"""
+import logging
+
+import docopt
+from ores.wsgi import server
+
+from .util import build_config
+
+
+def main(argv=None):
+    args = docopt.docopt(__doc__, argv=argv)
+    run(config_dirs=args['--config-dir'],
+        logging_config=args['--logging-config'])
+
+
+def run(*args, **kwargs):
+    application = build(*args, **kwargs)
+    logging.getLogger('ores').setLevel(logging.DEBUG)
+    application.debug = True
+    application.run(host="0.0.0.0", processes=64, debug=True)
+
+
+def build(*args, **kwargs):
+    config = build_config(*args, **kwargs)
+    return server.configure(config)

--- a/ores/ores.py
+++ b/ores/ores.py
@@ -6,6 +6,11 @@ This script provides access to a set of utilities for ORES
 * celery_worker -- Starts a "ScoreProcessor" celery worker
 * precached -- Starts a daemon that requests scores for revisions as they happen
 
+You can also launch a set of production like applications
+
+* applications.wsgi -- A wsgi server
+* applications.celery -- A celery worker
+
 {usage}
 Options:
     -h | --help  Shows this documentation
@@ -35,12 +40,18 @@ def main():
         sys.exit(1)
 
     module_name = sys.argv[1]
+
+    if module_name.find("application") == 0:
+        module_path = "." + module_name
+    else:
+        module_path = ".utilities." + module_name
+
     try:
         sys.path.insert(0, ".")
-        module = import_module(".utilities." + module_name, package="ores")
+        module = import_module(module_path, package="ores")
     except ImportError:
         sys.stderr.write(traceback.format_exc())
-        sys.stderr.write("Could not find utility {0}.\n".format(module_name))
+        sys.stderr.write("Could not find module {0}.\n".format(module_path))
         sys.exit(1)
 
     module.main(sys.argv[2:])


### PR DESCRIPTION
This replaces the functionality that was previously captured in https://github.com/wiki-ai/ores-wikimedia-config

You can run the application-based services with the regular utility: `./utility application.wsgi` or `./utility application.celery`.

Otherwise, you can configure uwsgi with `"ores.applications.wsgi:build()"`