### PR TITLE
Implements score_errored metrics

### DIFF
--- a/ores/scoring_systems/scoring_system.py
+++ b/ores/scoring_systems/scoring_system.py
@@ -5,11 +5,10 @@ import revscoring.errors
 import stopit
 
 from .. import errors
+from ..errors import TimeoutError
 from ..metrics_collectors import Null
 from ..score_caches import Empty
 from ..util import jsonify_error, timeout
-from ..errors import TimeoutError
-
 
 logger = logging.getLogger(__name__)
 
@@ -92,8 +91,8 @@ class ScoringSystem(dict):
 
         # 3.5. Record extraction errors
         for rev_id, error in extraction_errors.items():
-
             rev_scores[rev_id] = jsonify_error(error)
+            self.metrics_collector.score_errored(context_name, model_names)
 
         # 4. Generate scores (Heavy CPU)
         missing_scores, scoring_errors = self._process_missing_scores(
@@ -115,6 +114,7 @@ class ScoringSystem(dict):
         # 4.5 Record scoring errors
         for rev_id, error in scoring_errors.items():
             rev_scores[rev_id] = jsonify_error(error)
+            self.metrics_collector.score_errored(context_name, model_names)
 
         return {
             'models': model_info,


### PR DESCRIPTION
Good request:
```
2016-10-25 15:00:04,051 DEBUG:ores.metrics_collectors.logger -- score_cache_miss: testwiki:revid
2016-10-25 15:00:04,052 DEBUG:ores.metrics_collectors.logger -- score_processed: testwiki:{'revid'} in 0.001 seconds
2016-10-25 15:00:04,053 DEBUG:ores.metrics_collectors.logger -- scores_request: testwiki:{'revid'} for 1 revisions in 0.002 seconds
2016-10-25 15:00:04,054 INFO:werkzeug -- 127.0.0.1 - - [25/Oct/2016 15:00:04] "GET /v2/scores/testwiki/revid/99999 HTTP/1.1" 200 -
```

Request that causes a processing error:
```
2016-10-25 15:00:29,780 DEBUG:ores.metrics_collectors.logger -- score_cache_miss: testwiki:revid
2016-10-25 15:00:29,793 DEBUG:ores.metrics_collectors.logger -- score_errored: testwiki:{'revid'}
2016-10-25 15:00:29,794 DEBUG:ores.metrics_collectors.logger -- scores_request: testwiki:{'revid'} for 1 revisions in 0.014 seconds
2016-10-25 15:00:29,796 INFO:werkzeug -- 127.0.0.1 - - [25/Oct/2016 15:00:29] "GET /v2/scores/testwiki/?models=revid&revids=-1 HTTP/1.1" 200 -
```