### PR TITLE
Two small additions for Installation section of README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Then you can easily run a test server by:
 
 ``ores dev_server``
 
+Use the ``-h`` argument to view its usage.
+
+``ores dev_server -h``
+
 Authors
 =======
 * [Aaron Halfaker](http://halfaker.info)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ A webserver for hosting scoring services. For more information, see `https://met
 
 Installation
 ============
-Use pip to install ORES:
+ORES is based on Python 3. Use pip to install ORES:
 
-``pip install ores``
+``pip install ores`` (or ``pip3 install ores`` if your distribution defaults to Python 2)
 
 Then you can easily run a test server by:
 


### PR DESCRIPTION
Currently the guide assumes that the user has Python 3 in there system, which might not be the case for stable-ver. distros like Debian in which Python 2 is used by default.

I've also added the usage of the -h argument to encourage users to look at the help page.