### PR TITLE
Add celery.exceptions.TimeoutError to expected_errors in CeleryQueue

### DIFF
--- a/ores/scoring_systems/celery_queue.py
+++ b/ores/scoring_systems/celery_queue.py
@@ -57,7 +57,8 @@ class CeleryQueue(ScoringSystem):
                            revscoring.errors.DependencyError,
                            mwapi.errors.RequestError,
                            mwapi.errors.TimeoutError,
-                           errors.TimeoutError)
+                           errors.TimeoutError,
+                           celery.exceptions.TimeoutError)
 
         @self.application.task(throws=expected_errors,
                                queue=DEFAULT_CELERY_QUEUE)


### PR DESCRIPTION
Re: [T146681](https://phabricator.wikimedia.org/T146681)

The user-friendly message specified in the issue ('The operation timed out.') is not produced by ores nor mwapi, but by celery [itself](https://github.com/celery/celery/blob/e08620141e7a7791d26bff1e0ffb79386c48303e/celery/result.py#L615), when using the .get method of the celery result instance.  celery.exceptions.TimeoutError is caught by _process_missing_scores() but not by others -- like _lookup_score_in_map() in the Phabricator description -- so celery sees it as an unexpected error.

In the referenced commit I've added celery.exceptions.TimeoutError to the tuple of expected errors, which should solve this issue.