### PR TITLE
Normalizes celery timeout error and silences stopit 

### DIFF
--- a/ores/applications/celery.py
+++ b/ores/applications/celery.py
@@ -46,6 +46,7 @@ def run(verbose, debug, **kwargs):
                .setLevel(logging.INFO)
 
     logging.getLogger("ores.metrics_collectors.logger").setLevel(logging.DEBUG)
+    logging.getLogger("stopit").setLevel(logging.ERROR)
 
     application = build(**kwargs)
     logging.getLogger('ores').setLevel(logging.DEBUG)

--- a/ores/scorer_models/rev_id_scorer.py
+++ b/ores/scorer_models/rev_id_scorer.py
@@ -1,3 +1,5 @@
+import time
+
 from revscoring import ScorerModel
 from revscoring.datasources.revision_oriented import revision
 from revscoring.features import Feature
@@ -9,13 +11,17 @@ def process_reversed_last_two_in_rev_id(rev_id):
         return int(last_two + "0")
     else:
         return int("".join(reversed(last_two)))
-
 reversed_last_two_in_rev_id = Feature(
     "revision.reversed_last_two_in_rev_id",
     process_reversed_last_two_in_rev_id,
     returns=int,
     depends_on=[revision.id]
 )
+
+
+def process_delay():
+    return 0.0
+delay = Feature("delay", process_delay, returns=float)
 
 
 class RevIdScorer(ScorerModel):
@@ -26,10 +32,12 @@ class RevIdScorer(ScorerModel):
     E.g. 974623 = 32 and 23754929 = 92
     """
     def __init__(self, version=None):
-        super().__init__([reversed_last_two_in_rev_id], version=version)
+        super().__init__([reversed_last_two_in_rev_id, delay], version=version)
 
     def score(self, feature_values):
-        probability = feature_values[0] / 100
+        last_two_in_rev_id, delay = feature_values
+        time.sleep(delay)
+        probability = last_two_in_rev_id / 100
 
         if probability > 0.5:
             prediction = True


### PR DESCRIPTION
Note that I've also implemented a "delay" feature for the testing rev_id scorer.  This will allow us to test timeout error handling/logging more easily.  