### PR TITLE
Fixes some minor response formatting issues.

### DIFF
--- a/ores/wsgi/routes/v1/scores.py
+++ b/ores/wsgi/routes/v1/scores.py
@@ -35,7 +35,7 @@ def configure(config, bp, scoring_system):
             return responses.server_overloaded()
         except errors.MissingContext as e:
             return responses.not_found("No scorers available for {0}"
-                                       .format(context))
+                                       .format(e))
         except errors.MissingModels as e:
             context_name, model_names = e.args
             return responses.not_found(

--- a/ores/wsgi/routes/v1/util.py
+++ b/ores/wsgi/routes/v1/util.py
@@ -26,7 +26,7 @@ def format_v1_score_response(response, limit_to_model=None):
             response_doc[rev_id][model_name] = score
 
     for rev_id, rev_errors in response.errors.items():
-        for model_name, error in rev_errors:
+        for model_name, error in rev_errors.items():
             response_doc[rev_id][model_name] = util.format_error(error)
 
     if limit_to_model is not None:

--- a/ores/wsgi/routes/v2/scores.py
+++ b/ores/wsgi/routes/v2/scores.py
@@ -26,7 +26,7 @@ def configure(config, bp, scoring_system):
             return responses.server_overloaded()
         except errors.MissingContext as e:
             return responses.not_found("No scorers available for {0}"
-                                       .format(e[0]))
+                                       .format(e))
         except errors.MissingModels as e:
             context_name, model_names = e.args
             return responses.not_found(

--- a/ores/wsgi/routes/v2/util.py
+++ b/ores/wsgi/routes/v2/util.py
@@ -48,7 +48,7 @@ def format_v2_score_response(request, response):
 def format_v2_model(request, response, model_name):
 
     model_doc = defaultdict(dict)
-    model_doc['version'] = response.context[model_name].version
+    model_doc['version'] = response.context.model_version(model_name)
 
     if request.model_info and model_name in response.model_info:
         model_doc['info'] = response.model_info[model_name]

--- a/ores/wsgi/routes/v3/scores.py
+++ b/ores/wsgi/routes/v3/scores.py
@@ -27,7 +27,7 @@ def configure(config, bp, scoring_system):
             return responses.server_overloaded()
         except errors.MissingContext as e:
             return responses.not_found("No scorers available for {0}"
-                                       .format(e[0]))
+                                       .format(e))
         except errors.MissingModels as e:
             context_name, model_names = e.args
             return responses.not_found(

--- a/ores/wsgi/routes/v3/util.py
+++ b/ores/wsgi/routes/v3/util.py
@@ -1,4 +1,5 @@
 import traceback
+from collections import defaultdict
 
 from flask.ext.jsonpify import jsonify
 
@@ -38,12 +39,12 @@ def format_v3_score_response(response):
         }
     }
     """
-    context_doc = {}
+    context_doc = defaultdict(lambda: defaultdict(dict))
     if len(response.scores) > 0 or len(response.errors) > 0:
-        context_doc['scores'] = {
-            rev_id: {model_name: {'score': score}
-                     for model_name, score in rev_scores.items()}
-            for rev_id, rev_scores in response.scores.items()}
+        for rev_id, rev_scores in response.scores.items():
+            for model_name, score in rev_scores.items():
+                context_doc['scores'][rev_id][model_name] = \
+                    {'score': score}
 
         for rev_id, rev_errors in response.errors.items():
             for model_name, error in rev_errors.items():


### PR DESCRIPTION
Testing out the current HEAD on ores-staging, I get:
```
{
  "error": {
    "code": "internal server error",
    "message": "Traceback (most recent call last):\n  File \"./ores/wsgi/routes/v3/scores.py\", line 25, in process_score_request\n    return util.format_v3_score_response(score_response)\n  File \"./ores/wsgi/routes/v3/util.py\", line 51, in format_v3_score_response\n    util.format_error(error)\nKeyError: 23456784334346\n"
  }
}
```
For https://ores-staging.wmflabs.org/v3/scores/fiwiki/?revids=23456784334346

This PR fixes this issue.  