### PR TITLE
Always configure logging; log to console

### DIFF
--- a/ores/applications/celery.py
+++ b/ores/applications/celery.py
@@ -25,21 +25,21 @@ def main(argv=None):
     verbose = args['--verbose']
     debug = args['--debug']
 
-    run(verbose, debug,
+    run(verbose=verbose, debug=debug,
         logging_config=args['--logging-config'],
         config_dirs=args['--config-dir'])
 
 
-def run(verbose, debug, logging_config=None, **kwargs):
-    configure_logging(verbose, debug, logging_config)
-
+def run(**kwargs):
     application = build(**kwargs)
     application.worker_main(
         argv=["celery_worker"])
 
 
-def build(*args, **kwargs):
-    config = build_config(*args, **kwargs)
+def build(**kwargs):
+    configure_logging(**kwargs)
+
+    config = build_config(**kwargs)
     scoring_system = CeleryQueue.from_config(
         config, config['ores']['scoring_system'])
     return scoring_system.application

--- a/ores/applications/util.py
+++ b/ores/applications/util.py
@@ -3,8 +3,11 @@ import os.path
 import yamlconf
 import logging
 import logging.config
+import sys
 
 DEFAULT_DIRS = ["config/", "/etc/ores/"]
+DEFAULT_LOGGING_CONFIG = "logging_config.yaml"
+DEFAULT_FORMAT = "%(asctime)s %(levelname)s:%(name)s -- %(message)s"
 
 
 logger = logging.getLogger(__name__)
@@ -30,25 +33,40 @@ def build_config(config_dirs=DEFAULT_DIRS):
     return config
 
 
-def configure_logging(verbose, debug, logging_config=None):
-    # Load logging config if specified
+def configure_logging(verbose=False, debug=False, logging_config=None):
+    # Load logging config if specified.  If no config file is specified, we
+    # make a half-hearted attempt to find a distributed logging_config.yaml
+    # in the current working directory.
+    if logging_config is None:
+        if os.path.exists(DEFAULT_LOGGING_CONFIG):
+            logging_config = DEFAULT_LOGGING_CONFIG
+
     if logging_config is not None:
         with open(logging_config) as f:
             logging_config = yamlconf.load(f)
             logging.config.dictConfig(logging_config)
 
+        # Secret sauce: if running from the console, mirror logs there.
+        if sys.stdin.isatty():
+            handler = logging.StreamHandler(stream=sys.stdout)
+            formatter = logging.Formatter(fmt=DEFAULT_FORMAT)
+            handler.setFormatter(formatter)
+            logging.getLogger().addHandler(handler)
+
     else:
         # Configure fallback logging.
-        logging.basicConfig(
-            level=logging.DEBUG if debug else logging.INFO,
-            format='%(asctime)s %(levelname)s:%(name)s -- %(message)s'
-        )
+        logging.basicConfig(level=logging.INFO, format=DEFAULT_FORMAT)
         logging.getLogger('requests').setLevel(logging.INFO)
-        logging.getLogger('ores.metrics_collectors.logger').setLevel(logging.DEBUG)
         logging.getLogger('stopit').setLevel(logging.ERROR)
 
     # Command-line options can override some of the logging config, regardless
     # of whether logging_config.yaml was provided.
+    # TODO: Document and reconcile debug vs verbose.
+    if debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.getLogger('ores.metrics_collectors.logger') \
+               .setLevel(logging.DEBUG)
+
     if verbose:
         logging.getLogger('revscoring.dependencies.dependent') \
                .setLevel(logging.DEBUG)

--- a/ores/applications/util.py
+++ b/ores/applications/util.py
@@ -48,7 +48,7 @@ def configure_logging(verbose=False, debug=False, logging_config=None, **kwargs)
 
         # Secret sauce: if running from the console, mirror logs there.
         if sys.stdin.isatty():
-            handler = logging.StreamHandler(stream=sys.stdout)
+            handler = logging.StreamHandler(stream=sys.stderr)
             formatter = logging.Formatter(fmt=DEFAULT_FORMAT)
             handler.setFormatter(formatter)
             logging.getLogger().addHandler(handler)

--- a/ores/applications/util.py
+++ b/ores/applications/util.py
@@ -13,7 +13,7 @@ DEFAULT_FORMAT = "%(asctime)s %(levelname)s:%(name)s -- %(message)s"
 logger = logging.getLogger(__name__)
 
 
-def build_config(config_dirs=DEFAULT_DIRS):
+def build_config(config_dirs=DEFAULT_DIRS, **kwargs):
     # Loads files in alphabetical order based on the bare filename
     config_file_paths = []
     for directory in config_dirs:
@@ -33,7 +33,7 @@ def build_config(config_dirs=DEFAULT_DIRS):
     return config
 
 
-def configure_logging(verbose=False, debug=False, logging_config=None):
+def configure_logging(verbose=False, debug=False, logging_config=None, **kwargs):
     # Load logging config if specified.  If no config file is specified, we
     # make a half-hearted attempt to find a distributed logging_config.yaml
     # in the current working directory.

--- a/ores/applications/wsgi.py
+++ b/ores/applications/wsgi.py
@@ -39,19 +39,19 @@ def main(argv=None):
     verbose = args['--verbose']
     debug = args['--debug']
 
-    run(host, port, processes, verbose, debug,
+    run(host, port, processes,
+        verbose=verbose, debug=debug,
         logging_config=args['--logging-config'],
         config_dirs=args['--config-dir'])
 
 
-def run(host, port, processes, verbose, debug, logging_config=None, **kwargs):
-    configure_logging(verbose, debug, logging_config)
-
+def run(host, port, processes, **kwargs):
     application = build(**kwargs)
     application.debug = True
     application.run(host=host, port=port, processes=processes, debug=True)
 
 
-def build(*args, **kwargs):
-    config = build_config(*args, **kwargs)
+def build(**kwargs):
+    configure_logging(**kwargs)
+    config = build_config(**kwargs)
     return server.configure(config)


### PR DESCRIPTION
Push logging config down so it's executed from every entry point.
Detect whether we're running from the console, and mirror to console
if so.

Bug: https://phabricator.wikimedia.org/T182614