### PR TITLE
Prevent codecov from marking build failed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  status:
+    patch: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
 coverage:
   status:
     patch: off


### PR DESCRIPTION
We want to keep the informational stuff but not mark failures.