### PR TITLE
T183410/docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM python:3.5-slim
 
 RUN apt-get update && apt-get install -y \
-	g++ \
-	gfortran \
-	libblas-dev \
-	liblapack-dev \
-	libopenblas-dev \
-	python3-dev \
-	enchant \
-	redis-server \
-    build-essential \
-    npm \
-    nodejs
-
-RUN npm install -g eslint
+    g++ \
+    gfortran \
+    libblas-dev \
+    liblapack-dev \
+    libopenblas-dev \
+    python3-dev \
+    enchant \
+    build-essential
 
 COPY . /ores
 WORKDIR /ores

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.5-slim
+
+RUN apt-get update && apt-get install -y \
+	g++ \
+	gfortran \
+	libblas-dev \
+	liblapack-dev \
+	libopenblas-dev \
+	python3-dev \
+	enchant \
+	redis-server \
+    build-essential \
+    npm \
+    nodejs
+
+RUN npm install -g eslint
+
+COPY . /ores
+WORKDIR /ores
+
+RUN pip install pip --upgrade
+RUN pip install wheel
+RUN pip install nltk
+RUN pip install -r /ores/requirements.txt
+RUN pip install -r /ores/test-requirements.txt
+RUN pip install codecov pytest-cov
+RUN python -m nltk.downloader stopwords
+
+EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+define docker-run =
+	docker run --rm -ti \
+		ores/ores-service
+endef
+
+build-image:
+	docker build \
+		-t ores/ores-service:latest \
+		.
+
+shell:
+	$(docker-run) sh
+
+pytest:
+	$(docker-run) pytest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-define docker-run =
-	docker run --rm -ti \
-		ores/ores-service
-endef
+.PHONY: build-image shell pytest
+
+docker-run = docker run --rm -ti -p 8080:8080 ores/ores-service
 
 build-image:
 	docker build \


### PR DESCRIPTION
Docker base image for ORES service.

### Considerations:
* Used 'python:3.5-slim' from python's oficial repo @ DockerHub as a base image. That's python 3.5.5 on top of Debian jessie. If this needs to be changed, please, let me know.
* Looking at the travis file, there seems to be a redis server running. If that is a requirement, I'd suggest having that in another container. 
* In the case of requiring various services (as the redis), I'd suggest ddding a docker-compose file for dev purposes (it's convenient). If the trend to move to kubernetes pushes hard, minikube is also an option.
* Why is nodejs needed along python?

### Issues:
* When testing the installation, there seems to be something wrong/missing:
```
$ ./utility test_api http://localhost:8080 --debug
2018-05-18 15:57:13,313 DEBUG:ores.utilities.test_api -- Requesting /
2018-05-18 15:57:13,326 DEBUG:requests.packages.urllib3.connectionpool -- Starting new HTTP connection (1): localhost
2018-05-18 15:57:13,330 DEBUG:requests.packages.urllib3.connectionpool -- http://localhost:8080 "GET / HTTP/1.1" 301 241
2018-05-18 15:57:14,010 DEBUG:requests.packages.urllib3.connectionpool -- http://localhost:8080 "GET /w/index.php HTTP/1.1" 301 0
2018-05-18 15:57:15,015 DEBUG:requests.packages.urllib3.connectionpool -- http://localhost:8080 "GET /wiki/Main_Page HTTP/1.1" 200 4419
2018-05-18 15:57:15,016 DEBUG:ores.utilities.test_api -- Requesting /ui/
2018-05-18 15:57:15,018 DEBUG:requests.packages.urllib3.connectionpool -- Starting new HTTP connection (1): localhost
2018-05-18 15:57:15,020 DEBUG:requests.packages.urllib3.connectionpool -- http://localhost:8080 "GET /ui/ HTTP/1.1" 404 201
Traceback (most recent call last):
  File "./utility", line 4, in <module>
    ores.main()
  File "/home/vagrant/src/ores/ores/ores.py", line 57, in main
    module.main(sys.argv[2:])
  File "/home/vagrant/src/ores/ores/utilities/test_api.py", line 35, in main
    make_request(ores_url, "/ui/")
  File "/home/vagrant/src/ores/ores/utilities/test_api.py", line 142, in make_request
    response.status_code, path, response.content)
AssertionError: Status code mismatch 404 for /ui/: b'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested URL /ui/ was not found on this server.</p>\n</body></html>\n'
```

Beyond that, the image has all the depencies & is usable as it is.
